### PR TITLE
Replace window.confirm with custom component

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -46,6 +46,12 @@
   background-color: var(--brown);
 }
 
+// Syntax, Gray
+.button.gray {
+  color: var(--background);
+  background-color: var(--gray);
+}
+
 button.button,
 input.button[type="submit"],
 a.button {

--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -7,6 +7,7 @@
   --blue: #6484B5;
   --purple: #995785;
   --brown: #AC7155;
+  --gray: #9096a6;
   --foreground: black;
   --background: white;
   --inputBackground: whitesmoke;

--- a/app/javascript/components/ConfirmButton.tsx
+++ b/app/javascript/components/ConfirmButton.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from "react"
+
+// Necessary due to Safari's back-forward cache breaking native `window.confirm` on Safari iOS
+const ConfirmButton = ({ className, onSubmit, children }: { className: string, onSubmit: () => void, children: any }) => {
+  const [confirming, setConfirming] = useState(false)
+
+  const handlePress = () => {
+    if (confirming) {
+      // already confirmed
+      onSubmit()
+    } else {
+      setConfirming(true)
+    }
+  }
+
+  return (
+    <div style={{display: "flex"}}>
+      <button
+        className={className}
+        onClick={handlePress}>
+        {confirming ? "Tap to confirm" : children}
+      </button>
+      {confirming &&
+        <button
+          onClick={() => setConfirming(false)}
+          style={{marginLeft: '0.75em'}}
+          className="button gray button-wide">
+          Cancel
+        </button>
+      }
+    </div>
+  )
+}
+
+export default ConfirmButton

--- a/app/javascript/components/ProjectForm.tsx
+++ b/app/javascript/components/ProjectForm.tsx
@@ -6,6 +6,7 @@ import TextInput from "components/TextInput"
 import TextAreaInput from "components/TextAreaInput"
 import { ProjectI } from "interfaces"
 import { updateProject, createProject, deleteProject } from "repos/ProjectsRepo"
+import ConfirmButton from "./ConfirmButton"
 
 const ProjectForm = ({ project }: { project: ProjectI }) => {
   const authToken = useContext(AuthenticityTokenContext)
@@ -19,9 +20,7 @@ const ProjectForm = ({ project }: { project: ProjectI }) => {
   }
 
   const handleDelete = () => {
-    if (window.confirm("Are you sure that you want to delete this project?")) {
-      deleteProject(model, authToken).then(() => { history.push('/') })
-    }
+    deleteProject(model, authToken).then(() => { history.push('/') })
   }
 
   useEffect(() => setModel(project), [project])
@@ -58,7 +57,7 @@ const ProjectForm = ({ project }: { project: ProjectI }) => {
           className="button button-wide blue">Save</button>
       </form>
       <hr />
-      {project.id && <button onClick={handleDelete} className="button button-wide red">Delete Project</button>}
+      {project.id && <ConfirmButton onSubmit={handleDelete} className="button button-wide red">Delete Project</ConfirmButton>}
     </>
   )
 }

--- a/app/javascript/components/TodoForm.tsx
+++ b/app/javascript/components/TodoForm.tsx
@@ -6,6 +6,7 @@ import ProjectSelect from "components/ProjectSelect"
 import TextInput from "components/TextInput"
 import TextAreaInput from "components/TextAreaInput"
 import AuthenticityTokenContext from "contexts/AuthenticityTokenContext"
+import ConfirmButton from './ConfirmButton'
 import { ProjectI, TodoI } from "interfaces"
 import { createTodo, updateTodo, deleteTodo } from "repos/TodosRepo"
 
@@ -32,12 +33,10 @@ const TodoForm = ({ todo, currentProject }: { todo: TodoI, currentProject?: Proj
   }
 
   const handleDelete = () => {
-    if (window.confirm("Are you sure that you want to delete this todo?")) {
-      deleteTodo(model, authToken)
-        .then(() => {
-          history.push(currentProject ? `/projects/${currentProject.id}/todos` : '/')
-        })
-    }
+    deleteTodo(model, authToken)
+      .then(() => {
+        history.push(currentProject ? `/projects/${currentProject.id}/todos` : '/')
+      })
   }
 
   return (
@@ -81,7 +80,7 @@ const TodoForm = ({ todo, currentProject }: { todo: TodoI, currentProject?: Proj
         </button>
       </form>
       <hr />
-      {todo.id && <button onClick={handleDelete} className="button button-wide red">Delete Todo</button>}
+      {todo.id && <ConfirmButton className="button button-wide red" onSubmit={handleDelete}>Delete Todo</ConfirmButton>}
     </>
   )
 }


### PR DESCRIPTION
Safari on iOS has a broken window.confirm whenever history.pushState is used. Replaces the native confirmation with a two-stage button component.